### PR TITLE
fix error unknown unit were

### DIFF
--- a/piconyx
+++ b/piconyx
@@ -45,7 +45,7 @@ BEGIN {
 	verbose=0
 }
 
-/Traffic/ {
+/throughput/ {
 	users=users+1
 	gsub(/\|/," ")
 	up = up + tobyte($7,$8)


### PR DESCRIPTION
Have awk match with lines containing 'throughput' instead of 'Traffic' to work with later versions of snowflake proxy logging output.